### PR TITLE
Solution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,6 @@
+import multiprocessing
 import time
+from concurrent.futures import ProcessPoolExecutor
 from hashlib import sha256
 
 
@@ -20,8 +22,24 @@ def sha256_hash_str(to_hash: str) -> str:
     return sha256(to_hash.encode("utf-8")).hexdigest()
 
 
+def find_password(index: int) -> None:
+    name = multiprocessing.current_process().name
+    range_password = 10 ** 7
+    start, end = index * range_password, (index + 1) * range_password
+    for password in range(start, end):
+        str_password = str(password).zfill(8)
+        hashed_password = sha256_hash_str(str_password)
+        if hashed_password in PASSWORDS_TO_BRUTE_FORCE:
+            print(
+                f"Process name: {name} "
+                f"Password found: {str_password} "
+                f"Hash: {hashed_password}"
+            )
+
+
 def brute_force_password() -> None:
-    pass
+    with ProcessPoolExecutor() as executor:
+        executor.map(find_password, [index for index in range(8)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
![image_2024-03-02_15-48-51](https://github.com/mate-academy/py-brute-force-password/assets/37306964/b800ff34-b467-48bc-bf5d-09ec329b6031)

But I want to tell you about my fail :upside_down_face:. I spent the whole day solving my problem. I changed the code a hundred times. Used ProcessPoolExecutor and multiprocessing.Pool with .map , .submit . I changed the version of Python, I thought that the operating system was somehow blocking multiprocessing. But every time I got this result and didn’t understand why only one SpawnProcess was used:
![image_2024-03-02_16-33-56](https://github.com/mate-academy/py-brute-force-password/assets/37306964/e231a332-c5db-44a5-be57-52088e525d1c)
But the problem was in the range_password variable, I had range_password = 10 ** 8 in my code :see_no_evil: :see_no_evil: :see_no_evil:
