### PR TITLE
Script to check 10^8 possible paswords

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,11 @@
 import time
+from concurrent.futures import ProcessPoolExecutor
+from itertools import product, islice
 from hashlib import sha256
+from typing import Generator
 
 
-PASSWORDS_TO_BRUTE_FORCE = [
+PASSWORDS_TO_BRUTE_FORCE = {
     "b4061a4bcfe1a2cbf78286f3fab2fb578266d1bd16c414c650c5ac04dfc696e1",
     "cf0b0cfc90d8b4be14e00114827494ed5522e9aa1c7e6960515b58626cad0b44",
     "e34efeb4b9538a949655b788dcb517f4a82e997e9e95271ecd392ac073fe216d",
@@ -13,7 +16,10 @@ PASSWORDS_TO_BRUTE_FORCE = [
     "1273682fa19625ccedbe2de2817ba54dbb7894b7cefb08578826efad492f51c9",
     "7e8f0ada0a03cbee48a0883d549967647b3fca6efeb0a149242f19e4b68d53d6",
     "e5f3ff26aa8075ce7513552a9af1882b4fbc2a47a3525000f6eb887ab9622207",
-]
+}
+
+
+DIGITS = "0123456789"
 
 
 def sha256_hash_str(to_hash: str) -> str:
@@ -21,7 +27,37 @@ def sha256_hash_str(to_hash: str) -> str:
 
 
 def brute_force_password() -> None:
-    pass
+    batch_size = (10 ** 8) // 130
+    res = []
+    with ProcessPoolExecutor() as executor:
+        for batch_res in executor.map(
+                process_batch, password_batch_generator(batch_size)
+        ):
+            res.extend(batch_res)
+            if len(res) >= 10:
+                print(res)
+                executor.shutdown(wait=False)
+                return
+
+
+def password_batch_generator(
+    batch_size: int,
+) -> Generator[list[str], None, None]:
+
+    passwords = map("".join, product(DIGITS, repeat=8))
+    while True:
+        batch = list(islice(passwords, batch_size))
+        if not batch:
+            break
+        yield batch
+
+
+def process_batch(batch: list) -> list[str]:
+    found = []
+    for password in batch:
+        if sha256_hash_str(password) in PASSWORDS_TO_BRUTE_FORCE:
+            found.append(password)
+    return found
 
 
 if __name__ == "__main__":

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ def sha256_hash_str(to_hash: str) -> str:
 
 
 def brute_force_password() -> None:
-    batch_size = (10 ** 8) // 130
+    batch_size = (10 ** 8) // 160
     res = []
     with ProcessPoolExecutor() as executor:
         for batch_res in executor.map(


### PR DESCRIPTION
First versions took 73 seconds

Using map to instead of joini tuples brought it down to ~65

Using shutdown on reaching 10 found passwords brought it down to 50

And playing around with batch size - to 43 and finally to 38.

As I have 2-core CPU, it seems like acceptable result, but IDK
![image](https://github.com/user-attachments/assets/44db4de3-7f52-4feb-a3c4-63b9f798bc59)
